### PR TITLE
筆記公開按鈕

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,8 +87,6 @@ GEM
       warden (~> 1.2.3)
     erubi (1.10.0)
     ffi (1.15.3)
-    font-awesome-rails (4.7.0.7)
-      railties (>= 3.2, < 7)
     foreman (0.87.2)
     globalid (0.5.2)
       activesupport (>= 5.0)
@@ -234,7 +232,6 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise (~> 4.8.0)
-  font-awesome-rails
   foreman (~> 0.87.2)
   jbuilder (~> 2.7)
   kaminari (~> 1.2, >= 1.2.1)

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,15 +1,19 @@
 class NotesController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_user_note, only: [:show, :edit, :update, :destroy]
-
+  before_action :find_user_note, only: [:edit, :update, :destroy]
   def index
     @notes = current_user.notes.order(updated_at: :desc).search(params[:search]).page(params[:page])
   end
 
   def show
-    @comment = @note.comments.new
-    @comments = @note.comments.order(updated_at: :asc)
-    @likes = @note.likes.count
+    @note = Note.find(params[:id])
+    if !@note.public_status && @note.user != current_user
+      redirect_to "/"
+    else
+      @comment = @note.comments.new
+      @comments = @note.comments.order(updated_at: :asc)
+      @likes = @note.likes.count
+    end
   end
 
   def new
@@ -42,7 +46,15 @@ class NotesController < ApplicationController
     end
   end
 
-
+  def is_public
+    @note = Note.find(params[:id])
+    if @note.public_status
+      @note.update(public_status: false)
+    else
+      @note.update(public_status: true)
+    end
+    redirect_to note_path(@note)
+  end
 
   private 
   def note_params

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -21,4 +21,18 @@ module NotesHelper
     t = Time.now
     (( t - note.updated_at) / 1.day ).to_i
   end
+
+  def publicbtn_display(note)
+    if note.public_status && note.user != current_user 
+    else 
+      link_to "我要公開發表", is_public_note_path(note) 
+    end 
+  end
+  
+  def commentbtn_display(comment)
+    if comment.user_id == current_user.id
+      tag.i class: "fas fa-ellipsis-v"
+    else 
+    end
+  end
 end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -5,7 +5,7 @@ module NotesHelper
     else
       shape = 'far'
     end
-    content_tag(:i, '', class: ["fa-heart", "favorite_icon", shape], data: {'favorite-target': 'icon' })
+    content_tag(:i, '', class: ['fa-heart', 'favorite_icon', shape], data: { 'favorite-target': 'icon'})
   end
 
   def collection_icon(user, note)
@@ -14,25 +14,40 @@ module NotesHelper
     else
       shape = 'far'
     end
-    content_tag(:i, '', class: ["fa-bookmark", "collection_icon", shape], data: {'collect-target': 'icon' })
+    content_tag(:i, '', class: ['fa-bookmark', 'collection_icon', shape], data: { 'collect-target': 'icon'})
   end
 
   def day_difference(note)
     t = Time.now
-    (( t - note.updated_at) / 1.day ).to_i
+    ((t - note.updated_at) / 1.day).to_i
   end
 
   def publicbtn_display(note)
-    if note.public_status && note.user != current_user 
-    else 
-      link_to "我要公開發表", is_public_note_path(note) 
-    end 
+    if note.public_status && note.user != current_user
+    else
+      if note.public_status
+        link_to is_public_note_path(note),
+                class: 'h-8 w-48 border border-blue-600 flex justify-center items-center hover:border-gray-400 group' do
+          # content_tag 如要包多個 content_tag 需加 concat，來源：https://gist.github.com/abhilashak/a67eab371c54e1e71e1002f9c2dd791d?fbclid=IwAR1WNpsAtp8bR_AdrRjQycbzgK9PXegBOSdqCsQXPrrq7oo-W1ZNI0GH5vw
+          content_tag(:div, '', class: ['flex w-24 relative']) do
+            concat(content_tag(:i, '', class: ['fas fa-globe-asia text-sm text-blue-600  flex justify-center items-center group-hover:opacity-0']))
+            concat(content_tag(:span, '已公開發表', class: ['w-24 text-sm text-blue-600  group-hover:opacity-0']))
+            concat(content_tag(:span, '取消公開發表', class: ['w-24 text-sm text-gray-400 opacity-0 group-hover:opacity-100 absolute']))
+          end
+        end
+      else
+        link_to is_public_note_path(note),
+                class: 'h-8 w-48 border border-blue-600 flex justify-center items-center bg-blue-600 hover:bg-blue-700' do
+          content_tag(:div, '我要公開發表', class: ['block w-24 text-sm text-white'])
+        end
+      end
+    end
   end
-  
+
   def commentbtn_display(comment)
     if comment.user_id == current_user.id
-      tag.i class: "fas fa-ellipsis-v"
-    else 
+      content_tag(:i, '', class: ['fas fa-ellipsis-v'])
+    else
     end
   end
 end

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -7,7 +7,7 @@
     <div>
       <div class="flex justify-between">
         <div class="text-xl">
-          <%= current_user.name %>
+          <%= @comment.user.name %>
         </div>
         <button data-action="commentToggle#toggle">
           <i class="fas fa-ellipsis-v"></i>

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -10,7 +10,7 @@
           <%= @comment.user.name %>
         </div>
         <button data-action="commentToggle#toggle">
-          <i class="fas fa-ellipsis-v"></i>
+          <%= commentbtn_display(@comment) %>
         </button>
       </div>
       <div class="text-xs text-gray-400">

--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -7,10 +7,10 @@
     <div>
       <div class="flex justify-between">
         <div class="text-xl">
-          <%= @comment.user.name %>
+          <%= comment.user.name %>
         </div>
         <button data-action="commentToggle#toggle">
-          <%= commentbtn_display(@comment) %>
+          <%= commentbtn_display(comment) %>
         </button>
       </div>
       <div class="text-xs text-gray-400">

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -10,7 +10,7 @@
           <%#待放大頭貼current_user.photo%>
           <div class="flex justify-between">
             <div class="text-xl">
-              <%= current_user.name %>
+              <%= comment.user.name %>
             </div>
             <button data-action="commentToggle#toggle">
               <i class="fas fa-ellipsis-v"></i>

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -13,7 +13,7 @@
               <%= comment.user.name %>
             </div>
             <button data-action="commentToggle#toggle">
-              <i class="fas fa-ellipsis-v"></i>
+              <%= commentbtn_display(comment) %>
             </button>
           </div>
           <div class="text-xs text-gray-400">

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -26,14 +26,10 @@
     <br />
     標籤：<%= @note.tag_list %>
   </div>
-  <button class="text-red-600">
-    <%= link_to "我要公開發表", is_public_note_path(@note) %>
-  </button>
   <div data-controller="commentToggle" class="flex">
     <button
       class="bg-white text-base border border-gray-400 text-gray-600 w-8 h-8"
-      data-action="commentToggle#toggle"
-    >
+      data-action="commentToggle#toggle">
       <i class="fas fa-comment-dots"></i>
     </button>
     <div data-commentToggle-target="display" 
@@ -48,4 +44,7 @@
     </div>
   </div>
 </div>
+<button class="text-red-600">
+  <%= publicbtn_display(@note) %>
+</button>
 <div id="editor"></div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -44,7 +44,7 @@
     </div>
   </div>
 </div>
-<button class="text-red-600">
+<button>
   <%= publicbtn_display(@note) %>
 </button>
 <div id="editor"></div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,39 +1,39 @@
 <div><%= link_to "回筆記列表", notes_path %></div>
 
-
-<div data-controller="collect" 
-     data-collect-id-value="<%= @note.id %>">
+<div data-controller="collect" data-collect-id-value="<%= @note.id %>">
   <a data-action="collect#toggle">
-    <%= collection_icon(current_user, @note) %>收藏 
+    <%= collection_icon(current_user, @note) %>收藏
   </a>
 </div>
 
-<div data-controller="favorite" 
-     data-favorite-id-value="<%= @note.id %>">
-  <a href="#"
-     id = "favorite_btn"
-     data-action="favorite#toggleFavorite"
-     data-id="<%= @note.id %>">
-    <%= favorite_icon(current_user, @note) %>讚賞 
+<div data-controller="favorite" data-favorite-id-value="<%= @note.id %>">
+  <a
+    href="#"
+    id="favorite_btn"
+    data-action="favorite#toggleFavorite"
+    data-id="<%= @note.id %>"
+  >
+    <%= favorite_icon(current_user, @note) %>讚賞
   </a>
-    <span data-favorite-target='counter' >
-      <%= @likes %>
-    </span>
+  <span data-favorite-target="counter"> <%= @likes %> </span>
 </div>
 
-<div style="display: flex;">
+<div style="display: flex">
   <div>
     標題：<%= @note.title %>
-    <br>
+    <br />
     內文：<%= @note.content %>
-    <br>
+    <br />
     標籤：<%= @note.tag_list %>
   </div>
-
-  <div data-controller="commentToggle" 
-       class="flex">
-    <button class="bg-white text-base border border-gray-400 text-gray-600 w-8 h-8" 
-            data-action="commentToggle#toggle">
+  <button class="text-red-600">
+    <%= link_to "我要公開發表", is_public_note_path(@note) %>
+  </button>
+  <div data-controller="commentToggle" class="flex">
+    <button
+      class="bg-white text-base border border-gray-400 text-gray-600 w-8 h-8"
+      data-action="commentToggle#toggle"
+    >
       <i class="fas fa-comment-dots"></i>
     </button>
     <div data-commentToggle-target="display" 
@@ -48,5 +48,4 @@
     </div>
   </div>
 </div>
-
 <div id="editor"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,11 @@ Rails.application.routes.draw do
   get "/", to: "notes#index"
   get "/users/collections", to: "users/collections#index"
   get "/users/profiles/:id", to: "users/profiles#public_note", as: 'user_public_note'
-  
+
   resources :notes do
+    member do
+      get :is_public
+    end
     resources :comments, shallow: true, only: [:create, :destroy]
   end
   

--- a/db/migrate/20210913070408_add_note_is_public.rb
+++ b/db/migrate/20210913070408_add_note_is_public.rb
@@ -1,0 +1,5 @@
+class AddNoteIsPublic < ActiveRecord::Migration[6.1]
+  def change
+    add_column :notes, :public_status, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,85 +10,90 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_04_084804) do
-
+ActiveRecord::Schema.define(version: 2021_09_13_070408) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "collections", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "note_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["note_id"], name: "index_collections_on_note_id"
-    t.index ["user_id"], name: "index_collections_on_user_id"
+  create_table 'collections', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'note_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['note_id'], name: 'index_collections_on_note_id'
+    t.index ['user_id'], name: 'index_collections_on_user_id'
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.text "content"
-    t.bigint "note_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["note_id"], name: "index_comments_on_note_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.text 'content'
+    t.bigint 'note_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['note_id'], name: 'index_comments_on_note_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "likes", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "note_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["note_id"], name: "index_likes_on_note_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
+  create_table 'likes', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'note_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['note_id'], name: 'index_likes_on_note_id'
+    t.index ['user_id'], name: 'index_likes_on_user_id'
   end
 
-  create_table "notes", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_notes_on_user_id"
+  create_table 'notes', force: :cascade do |t|
+    t.string 'title'
+    t.text 'content'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'user_id'
+    t.boolean 'comment_status', default: true
+    t.boolean 'edit_status', default: true
+    t.boolean 'invitation_status'
+    t.boolean 'public_status', default: false
+    t.index ['user_id'], name: 'index_notes_on_user_id'
   end
 
-  create_table "taggings", force: :cascade do |t|
-    t.bigint "tag_id", null: false
-    t.bigint "note_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["note_id"], name: "index_taggings_on_note_id"
-    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+  create_table 'taggings', force: :cascade do |t|
+    t.bigint 'tag_id', null: false
+    t.bigint 'note_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['note_id'], name: 'index_taggings_on_note_id'
+    t.index ['tag_id'], name: 'index_taggings_on_tag_id'
   end
 
-  create_table "tags", force: :cascade do |t|
-    t.string "title"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+  create_table 'tags', force: :cascade do |t|
+    t.string 'title'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name"
-    t.string "photo"
-    t.text "intro"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name'
+    t.string 'photo'
+    t.text 'intro'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'],
+            name: 'index_users_on_reset_password_token',
+            unique: true
   end
 
-  add_foreign_key "collections", "notes"
-  add_foreign_key "collections", "users"
-  add_foreign_key "comments", "notes"
-  add_foreign_key "comments", "users"
-  add_foreign_key "likes", "notes"
-  add_foreign_key "likes", "users"
-  add_foreign_key "notes", "users"
-  add_foreign_key "taggings", "notes"
-  add_foreign_key "taggings", "tags"
+  add_foreign_key 'collections', 'notes'
+  add_foreign_key 'collections', 'users'
+  add_foreign_key 'comments', 'notes'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'likes', 'notes'
+  add_foreign_key 'likes', 'users'
+  add_foreign_key 'notes', 'users'
+  add_foreign_key 'taggings', 'notes'
+  add_foreign_key 'taggings', 'tags'
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,6 +948,13 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@prettier/plugin-ruby@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-1.6.1.tgz#14489985513a72e052b57c1cf9beae288880faa8"
+  integrity sha512-PGDCATgVTQz0s/NB9nStiXVCIr+hG/XnKeAO/kguaHrNf8VwCpP5Ul+/KQao0z0QFBy2PDY8kWptfDQCa7WMXg==
+  dependencies:
+    prettier ">=1.10"
+
 "@rails/actioncable@^6.0.0":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.4.tgz#c3c5a9f8302c429af9722b6c50ab48049016d2a3"
@@ -3288,6 +3295,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
+  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -6562,6 +6573,11 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier@>=1.10, prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
目前與留言一樣先不考慮非使用者的狀況
現在公開之後可以讓其他使用者看到自己公開的那篇文章
測試方式：開無痕視窗把那篇筆記的網址貼過去，已公開就可以看得到，未公開會被導向自己的 index 頁面

已完成：
1. 筆記公開按鈕的基本功能
2. 筆記公開按鈕的切版
3. 非留言者不能編輯、刪除留言

備註：
因為目前 show 頁面尚未切版完畢，因此我先把按鈕放置在標籤下方
待負責 show 頁面的人完成後再移到與 HackMD 同樣地方

<img width="281" alt="截圖 2021-09-19 下午7 45 21" src="https://user-images.githubusercontent.com/31040771/133926303-79e01fbe-499f-4c9a-9597-7054b811b6f9.png">
<img width="281" alt="截圖 2021-09-19 下午7 45 06" src="https://user-images.githubusercontent.com/31040771/133926315-1645dd78-176e-4fd7-970f-ba2c1a57505c.png">
<img width="281" alt="截圖 2021-09-19 下午7 45 13" src="https://user-images.githubusercontent.com/31040771/133926321-ef30baaf-82d8-417b-ab84-ed26b9bf7b5f.png">

https://user-images.githubusercontent.com/31040771/133926252-443fcc39-c0b6-4df0-be0e-05f750cac8c8.mov