### PR TITLE
修改留言時間格式

### DIFF
--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -1,4 +1,3 @@
-<%# 新留言用 create.js.erb render 出來的 %>
 <div class="relative">
   <div id="comment_<%= comment.id %>"
        data-controller="editComment commentToggle"
@@ -14,7 +13,7 @@
         </button>
       </div>
       <div class="text-xs text-gray-400">
-        <%=comment.updated_at%>
+        <%= comment.updated_at.strftime("%Y-%m-%d %H:%M:%S") %>
       </div>
       <div data-editComment-target="text" 
            class="mb-2">

--- a/app/views/notes/_comments.html.erb
+++ b/app/views/notes/_comments.html.erb
@@ -1,4 +1,3 @@
-<%# 舊留言 %>
 <div>
   <% comments.each do |comment| %>
     <div class="relative">
@@ -7,7 +6,7 @@
            data-editComment-id-value="<%= comment.id %>"
            class="px-3.5 border-b border-gray-300 mb-2">
         <div>
-          <%#待放大頭貼current_user.photo%>
+          <%#待放大頭貼comment.user.photo%>
           <div class="flex justify-between">
             <div class="text-xl">
               <%= comment.user.name %>
@@ -17,7 +16,8 @@
             </button>
           </div>
           <div class="text-xs text-gray-400">
-            <%= comment.updated_at %>
+            <%#strftime客製化時間形式%>
+            <%= comment.updated_at.strftime("%Y-%m-%d %H:%M:%S") %>
           </div>
           <div data-editComment-target="text"
                class="mb-2">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,7 +86,6 @@ ActiveRecord::Schema.define(version: 2021_09_17_073618) do
             unique: true
   end
 
-<<<<<<< HEAD
   add_foreign_key 'collections', 'notes'
   add_foreign_key 'collections', 'users'
   add_foreign_key 'comments', 'notes'
@@ -96,11 +95,4 @@ ActiveRecord::Schema.define(version: 2021_09_17_073618) do
   add_foreign_key 'notes', 'users'
   add_foreign_key 'taggings', 'notes'
   add_foreign_key 'taggings', 'tags'
-=======
-  add_foreign_key "collections", "notes"
-  add_foreign_key "comments", "notes"
-  add_foreign_key "likes", "notes"
-  add_foreign_key "taggings", "notes"
-  add_foreign_key "taggings", "tags"
->>>>>>> 001b493 (新增排序功能)
 end


### PR DESCRIPTION
已修改：
把原本 Rails 時間預設的+08:00 去掉
<img width="328" alt="截圖 2021-09-21 下午4 29 14" src="https://user-images.githubusercontent.com/31040771/134138320-49743b52-281a-4b51-b330-2c63a000bbf2.png">
