### PR TITLE
調整按讚、收藏、留言位置至editor內

### DIFF
--- a/app/assets/images/side-nav-toggle.svg
+++ b/app/assets/images/side-nav-toggle.svg
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid meet" viewBox="0 0 640 640" width="640" height="640"><defs><path d="M280 158L240 200.5L280 243L280 158Z" id="b1ohBKZ4M"></path><path d="M305 280L305 120L335 120L335 280L305 280Z" id="b1ba8ibMTP"></path></defs><g><g><g><use xlink:href="#b1ohBKZ4M" opacity="1" fill="#545454" fill-opacity="1"></use></g><g><use xlink:href="#b1ba8ibMTP" opacity="1" fill="#545454" fill-opacity="1"></use></g></g></g></svg>

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,2 +1,0 @@
-module CommentsHelper
-end

--- a/app/helpers/users/collections_helper.rb
+++ b/app/helpers/users/collections_helper.rb
@@ -1,2 +1,0 @@
-module Users::CollectionsHelper
-end

--- a/app/javascript/reactjs/editor.jsx
+++ b/app/javascript/reactjs/editor.jsx
@@ -47,6 +47,6 @@ const Dome = () => {
   )
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbolinks:load", () => {
   ReactDOM.render(<Dome />, document.getElementById("editor"))
 })

--- a/app/javascript/reactjs/editor.jsx
+++ b/app/javascript/reactjs/editor.jsx
@@ -41,7 +41,6 @@ const Dome = () => {
         "link",
         "image",
       ]}
-      // height="full"
       visible="true" 
       styleActiveLine= "true"
     />

--- a/app/javascript/reactjs/editor.jsx
+++ b/app/javascript/reactjs/editor.jsx
@@ -41,7 +41,7 @@ const Dome = () => {
         "link",
         "image",
       ]}
-      height="800px"
+      // height="full"
       visible="true" 
       styleActiveLine= "true"
     />

--- a/app/javascript/reactjs/editor.jsx
+++ b/app/javascript/reactjs/editor.jsx
@@ -49,5 +49,8 @@ const Dome = () => {
 }
 
 document.addEventListener("turbolinks:load", () => {
-  ReactDOM.render(<Dome />, document.getElementById("editor"))
+  var show = document.getElementById('editor')
+  if ( show ) {
+    ReactDOM.render(<Dome />, show);
+  }
 })

--- a/app/javascript/styles/comment.scss
+++ b/app/javascript/styles/comment.scss
@@ -2,8 +2,8 @@
   @apply cursor-pointer border rounded py-0.5 px-2;
 }
 .commentbtnhover {
-  @apply hover:bg-gray-200 w-20 text-center text-xs
+  @apply hover:bg-gray-200 w-20 text-center text-base
 }
 .commentinnerbg {
-  @apply flex flex-col justify-center items-center bg-white w-20 h-20 shadow-md
+  @apply flex flex-col justify-center items-center bg-white w-20 h-20 shadow-md border border-gray-lightest_xs
 }

--- a/app/javascript/styles/editor.scss
+++ b/app/javascript/styles/editor.scss
@@ -50,8 +50,6 @@
   letter-spacing: 0.025em;
   line-height: 1.25;
   font-size: 18px !important;
-  // height: 500px !important;
-  
   overflow-y: hidden !important;
   -webkit-overflow-scrolling: touch;
 }
@@ -74,7 +72,6 @@
 .CodeMirror-linenumber {
   padding: 0 3px 0 5px !important;
   color: #999;
-  // width: 36px;
   text-align: right;
   box-sizing: content-box;
   white-space: nowrap;

--- a/app/javascript/styles/editor.scss
+++ b/app/javascript/styles/editor.scss
@@ -1,6 +1,6 @@
 .md-editor-toolbar {
   background: #1c1c1e !important;
-  border-bottom: 1px solid #343434;
+  border-bottom: 1px solid #343434 !important;
   color: #ccc;
   position: relative;
   display: block;
@@ -59,6 +59,12 @@
 .CodeMirror-gutter {
   background: #333 !important;
 }
+.CodeMirror-line {
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  word-break: normal;
+}
+
 .CodeMirror-linenumber {
   padding: 0 3px 0 5px !important;
   color: #999;
@@ -196,4 +202,7 @@
 .wmde-markdown p {
   color: #333;
   font-weight: 400;
+}
+.cm-invalidchar {
+  opacity: 0;
 }

--- a/app/javascript/styles/editor.scss
+++ b/app/javascript/styles/editor.scss
@@ -131,7 +131,7 @@
 // preview
 .md-editor-preview {
   background-color: #f8f8f8;
-  padding: 10px !important;
+  padding: 30px 10px 10px 10px !important;
   width: 0%;
   overflow: hidden;
   border-left: 0;

--- a/app/javascript/styles/editor.scss
+++ b/app/javascript/styles/editor.scss
@@ -20,12 +20,16 @@
   border-radius: 3px;
 }
 #editor {
+  
   ol {
     list-style-type: decimal;
   }
 }
 .CodeMirror-selected {
   background: #34455a !important;
+}
+.CodeMirror-sizer {
+  height: calc(100vh - 90px) !important;
 }
 .md-editor {
   color: #abb2bf !important;
@@ -38,6 +42,7 @@
   background-color: #333 !important;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   font-weight: bold;
+  
 }
 .CodeMirror {
   color: #abb2bf !important;
@@ -45,7 +50,8 @@
   letter-spacing: 0.025em;
   line-height: 1.25;
   font-size: 18px !important;
-  height: 700px !important;
+  // height: 500px !important;
+  
   overflow-y: hidden !important;
   -webkit-overflow-scrolling: touch;
 }

--- a/app/javascript/styles/editor.scss
+++ b/app/javascript/styles/editor.scss
@@ -34,6 +34,7 @@
     0 1px 1px rgb(16 22 26 / 20%);
   border-radius: 3px;
   position: relative;
+  z-index: 0;
   background-color: #333 !important;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   font-weight: bold;

--- a/app/javascript/styles/noteShow.scss
+++ b/app/javascript/styles/noteShow.scss
@@ -5,9 +5,6 @@
 .editor-nav {
   @apply h-12 text-xl font-semibold bg-gray-lightest_xs p-2 flex-none flex
 }
-.editor {
-  height: calc(100% - 48px);
-}
 .logol {
   @apply inline-block flex items-center text-gray-lightest_s hover:text-gray-lightest text-lg;
   i {

--- a/app/javascript/styles/sign_in_up.scss
+++ b/app/javascript/styles/sign_in_up.scss
@@ -1,11 +1,14 @@
+.sign-full {
+  @apply bg-gray-rackmd h-screen
+}
 .sign-header {
-  @apply bg-gray-600 p-2 text-gray-300 fixed w-screen
+  @apply bg-gray-600 p-2 text-gray-300 sticky w-screen
 }
 .sign-header-text {
-  @apply text-xl inline-block w-28 hover:text-gray-400
+  @apply text-xl inline-block w-36 hover:text-gray-400
 }
 .sign-screen {
-  @apply bg-gray-rackmd h-screen pt-16 flex justify-center
+  @apply flex justify-center pt-5
 }
 .sign-title {
   @apply text-gray-300 text-2xl font-bold text-center

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,57 +1,59 @@
-<nav class="sign-header">
-  <%= link_to notes_path do %>
-    <i class="fas fa-book-open sign-header-text"> RackMD</i>
-  <% end %>
-</nav>
-<section class="sign-screen">
-  <div class="w-96">
-    <h2 class="sign-title">註冊</h2>
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
-      <div class="field my-2">
-        <%= f.label :使用者名稱, class:"sign-sectitle" %>
-        <div class="text-center">
-          <%= f.text_field :name, autofocus: true, 
-                                  autocomplete: "name", 
-                                  class: "sign-input",
-                                  placeholder: "您的使用者名稱" %>
-        </div>
-        <div class="sign-remind">
-          僅允許輸入中文、a-Z、0-9 以及 - 號 (非首位字元)
-        </div>
-      </div>
-      <div class="field my-2">
-        <%= f.label :email, class:"sign-sectitle" %>
-        <div class="text-center">
-          <%= f.email_field :email, autofocus: true, 
-                                    autocomplete: "email", 
-                                    class: "sign-input",
-                                    placeholder: "您的 Email" %>
-        </div>
-      </div>
-      <div class="field my-2">
-        <%= f.label :密碼, class:"sign-sectitle" %>
-        <div class="text-center">
-          <%= f.password_field :password, autocomplete: "new-password", 
-                                          class: "sign-input",
-                                          placeholder: "您的密碼"%>
-        </div>
-        <div class="sign-remind">
-          密碼長度須大於五個字。
-        </div>
-      </div>
-      <div class="sign-text">
-        繼續登入，代表您同意<a href="#" class="sign-a-hover">服務條款</a>。
-      </div>
-      <div class="actions text-center my-3">
-        <%= f.submit "註冊", class:"sign-btn" %>
-      </div>
-      <div class="sign-text">
-        或是
-      </div><br />
+<div class="sign-full">
+  <nav class="sign-header">
+    <%= link_to notes_path do %>
+      <i class="fas fa-book-open sign-header-text"> RackMD</i>
     <% end %>
-    <div class="sign-text">
-      <%= render "devise/shared/links" %>
+  </nav>
+  <section class="sign-screen">
+    <div class="w-96">
+      <h2 class="sign-title">註冊</h2>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="field my-2">
+          <%= f.label :使用者名稱, class:"sign-sectitle" %>
+          <div class="text-center">
+            <%= f.text_field :name, autofocus: true,
+                                    autocomplete: "name",
+                                    class: "sign-input",
+                                    placeholder: "您的使用者名稱" %>
+          </div>
+          <div class="sign-remind">
+            僅允許輸入中文、a-Z、0-9 以及 - 號 (非首位字元)
+          </div>
+        </div>
+        <div class="field my-2">
+          <%= f.label :email, class:"sign-sectitle" %>
+          <div class="text-center">
+            <%= f.email_field :email, autofocus: true,
+                                      autocomplete: "email",
+                                      class: "sign-input",
+                                      placeholder: "您的 Email" %>
+          </div>
+        </div>
+        <div class="field my-2">
+          <%= f.label :密碼, class:"sign-sectitle" %>
+          <div class="text-center">
+            <%= f.password_field :password, autocomplete: "new-password",
+                                            class: "sign-input",
+                                            placeholder: "您的密碼"%>
+          </div>
+          <div class="sign-remind">
+            密碼長度須大於五個字。
+          </div>
+        </div>
+        <div class="sign-text">
+          繼續登入，代表您同意<a href="#" class="sign-a-hover">服務條款</a>。
+        </div>
+        <div class="actions text-center my-3">
+          <%= f.submit "註冊", class:"sign-btn" %>
+        </div>
+        <div class="sign-text">
+          或是
+        </div><br />
+      <% end %>
+      <div class="sign-text">
+        <%= render "devise/shared/links" %>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,49 +1,51 @@
-<nav class="sign-header">
-  <%= link_to notes_path do %>
-    <i class="fas fa-book-open sign-header-text"> RackMD</i>
-  <% end %>
-</nav>
-<section class="sign-screen">
-  <div class="w-96">
-    <h2 class="sign-title">登入</h2>
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
-      <div class="field my-2">
-        <%= f.label :email, class:"sign-sectitle" %>
-        <div class="text-center">
-          <%= f.email_field :email, autofocus: true, 
-                                    autocomplete: "email", 
-                                    class: "sign-input",
-                                    placeholder: "您的 Email" %>
-        </div>
-      </div>
-      <div class="field my-2">
-        <%= f.label :密碼, class:"sign-sectitle" %>
-        <div class="text-center">
-          <%= f.password_field :password, autocomplete: "current-password", 
-                                          class: "sign-input",
-                                          placeholder: "您的密碼"%>
-        </div>
-        <% if devise_mapping.rememberable? %>
-          <div class="field text-gray-300 text-sm ml-8 mt-1">
-            <%= f.check_box :remember_me %>
-            <%= f.label :"記住密碼" %>
-          </div>
-        <% end %>
-      </div>
-      
-      <div class="actions text-center my-4">
-        <%= f.submit "登入", class:"sign-btn" %>
-      </div>
-      <div class="sign-text my-4">
-        或是
-      </div>
-      <div class="sign-text my-4">
-        繼續登入，代表您同意<a href="#" class="sign-a-hover">服務條款</a>。
-      </div>
+<div class="sign-full">
+  <nav class="sign-header">
+    <%= link_to notes_path do %>
+      <i class="fas fa-book-open sign-header-text"> RackMD</i>
     <% end %>
-    <div class="sign-text">
-      <%= render "devise/shared/links" %>
+  </nav>
+  <section class="sign-screen">
+    <div class="w-96">
+      <h2 class="sign-title">登入</h2>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="field my-2">
+          <%= f.label :email, class:"sign-sectitle" %>
+          <div class="text-center">
+            <%= f.email_field :email, autofocus: true,
+                                      autocomplete: "email",
+                                      class: "sign-input",
+                                      placeholder: "您的 Email" %>
+          </div>
+        </div>
+        <div class="field my-2">
+          <%= f.label :密碼, class:"sign-sectitle" %>
+          <div class="text-center">
+            <%= f.password_field :password, autocomplete: "current-password",
+                                            class: "sign-input",
+                                            placeholder: "您的密碼"%>
+          </div>
+          <% if devise_mapping.rememberable? %>
+            <div class="field text-gray-300 text-sm ml-8 mt-1">
+              <%= f.check_box :remember_me %>
+              <%= f.label :"記住密碼" %>
+            </div>
+          <% end %>
+        </div>
+  
+        <div class="actions text-center my-4">
+          <%= f.submit "登入", class:"sign-btn" %>
+        </div>
+        <div class="sign-text my-4">
+          或是
+        </div>
+        <div class="sign-text my-4">
+          繼續登入，代表您同意<a href="#" class="sign-a-hover">服務條款</a>。
+        </div>
+      <% end %>
+      <div class="sign-text">
+        <%= render "devise/shared/links" %>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+</div>

--- a/app/views/devise/shared/_linksedit.html.erb
+++ b/app/views/devise/shared/_linksedit.html.erb
@@ -1,7 +1,7 @@
 <div class="justify-center order-none">
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= link_to " 透過 #{OmniAuth::Utils.camelize(provider)} 登入", omniauth_authorize_path(resource_name, provider), class:"fab fa-github text-xl sign-github p-2", method: :post %>
+      <%= link_to " #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class:"fab fa-github text-xl sign-github p-2 w-36", method: :post %>
     <% end %>
   <% end %>    
 </div><br />

--- a/app/views/notes/_createComment.html.erb
+++ b/app/views/notes/_createComment.html.erb
@@ -1,14 +1,14 @@
 <div data-controller="commentToggle">
   <%= form_with(model: comment, url: note_comments_path(note), local: false) do |f| %>
-    <div class="flex justify-center items-center h-20">
+    <div class="text-center">
       <%= f.text_area :content, 
           placeholder:"輸入您的留言...", 
           data: {action: "click->commentToggle#toggle"}, 
-          class:"border-solid border border-gray-300 rounded text-sm h-12 w-56" %>
+          class:"border-solid border border-gray-300 rounded text-sm h-16 w-44" %>
     </div>
-    <div data-commentToggle-target="display" style="display: none;">
-      <%= f.submit "送出",class:"commentbtn bg-blue-500 hover:bg-blue-600 text-white ml-5 mb-3" %>
-      <button class="commentbtn ml-2 text-gray-400 hover:text-white hover:bg-gray-500 "
+    <div data-commentToggle-target="display"; style="display: none"; class="mt-2">
+      <%= f.submit "送出",class:"commentbtn bg-blue-500 hover:bg-blue-600 text-white ml-3 mb-3" %>
+      <button class="commentbtn ml-2 text-gray-400 hover:text-white hover:bg-gray-500"
               data-action="commentToggle#hide">
         取消
       </button>

--- a/app/views/notes/_createComment.html.erb
+++ b/app/views/notes/_createComment.html.erb
@@ -7,7 +7,7 @@
           class:"border-solid border border-gray-300 rounded text-sm h-12 w-56" %>
     </div>
     <div data-commentToggle-target="display" style="display: none;">
-      <%= f.submit "送出",class:"commentbtn bg-blue-500 hover:bg-blue-600 ml-5 mb-3" %>
+      <%= f.submit "送出",class:"commentbtn bg-blue-500 hover:bg-blue-600 text-white ml-5 mb-3" %>
       <button class="commentbtn ml-2 text-gray-400 hover:text-white hover:bg-gray-500 "
               data-action="commentToggle#hide">
         取消

--- a/app/views/notes/_side_bar.html.erb
+++ b/app/views/notes/_side_bar.html.erb
@@ -79,7 +79,7 @@
                 <% end %>
               </div>
               <div>
-                <%= link_to user_public_note_path(current_user.id), class:'pl-3.5 py-1.5' do %>
+                <%= link_to user_private_note_private_path(current_user.id), class:'pl-3.5 py-1.5' do %>
                   <i class="fas fa-user-alt w-24"
                      style="line-height: 14px; height: 14px; font-size: 14px;"> 個人公開頁</i>
                 <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,19 +1,20 @@
-<nav class="editor-nav justify-between">
-  <div class="flex">
-    <div class="logol">
-      <%= link_to notes_path do %>
-        <i class="fas fa-book-open text-xl"></i>RackMD
-      <% end %>
+<div class="h-screen">
+  <nav class="editor-nav justify-between">
+    <div class="flex">
+      <div class="logol">
+        <%= link_to notes_path do %>
+          <i class="fas fa-book-open text-xl"></i>RackMD
+        <% end %>
+      </div>
+      <div class="switch-btns">
+        <i class="fas fa-pencil-alt"></i>
+        <i class="fas fa-columns"></i>
+        <i class="far fa-eye"></i>
+      </div>
     </div>
-    <div class="switch-btns">
-      <i class="fas fa-pencil-alt"></i>
-      <i class="fas fa-columns"></i>
-      <i class="far fa-eye"></i>
-    </div>
-  </div>
   
-  <div data-controller="commentToggle"
-        class="flex items-center relative">
+    <div data-controller="commentToggle"
+          class="flex items-center relative">
       <i data-action="click->commentToggle#toggle"
           class="fas fa-share-alt text-lg text-gray-lightest_s hover:text-gray-rackmd cursor-pointer">
       </i>
@@ -34,62 +35,63 @@
       <button class="flex items-center text-white bg-blue-500 hover:bg-blue-600 py-1 rounded">
         <i class="fas fa-users text-xs w-16"> 1 連線</i>
       </button>
-  </div>
-</nav>
-
-<div class="flex"
-     data-controller="commentToggle">
-  <div class="relative w-screen">
-    <div id="editor" data-controller="autosave"
-                     data-action="keyup->autosave#updateValue"
-                     data-addTags-target="editor"
-                     data-addTags-id-value="<%= @note.id %>"
-                     data-autosave-id-value="<%= @note.id %>"
-                     data-content="<%= @note.content %>"
-                     class="w-full">
     </div>
-    <div class="absolute right-0 top-12 z-10">
-      <div class="flex items-center">
-        <div class="icon-btns">
-          <div data-controller="favorite"
-              data-favorite-id-value="<%= @note.id %>">
-            <a href="#"
-              id = "favorite_btn"
-              data-action="favorite#addFavorite"
-              data-id="<%= @note.id %>">
-              <%= favorite_icon(current_user, @note) %>
-            </a>
-            <span data-favorite-target='counter' >
-              <%= @likes %>
-            </span>
+  </nav>
+  
+  <div class="flex"
+       data-controller="commentToggle">
+    <div class="relative w-screen">
+      <div id="editor" data-controller="autosave"
+                       data-action="keyup->autosave#updateValue"
+                       data-addTags-target="editor"
+                       data-addTags-id-value="<%= @note.id %>"
+                       data-autosave-id-value="<%= @note.id %>"
+                       data-content="<%= @note.content %>"
+                       class="w-full">
+      </div>
+      <div class="absolute right-0 top-12 z-10">
+        <div class="flex items-center">
+          <div class="icon-btns">
+            <div data-controller="favorite"
+                data-favorite-id-value="<%= @note.id %>">
+              <a href="#"
+                id = "favorite_btn"
+                data-action="favorite#addFavorite"
+                data-id="<%= @note.id %>">
+                <%= favorite_icon(current_user, @note) %>
+              </a>
+              <span data-favorite-target='counter' >
+                <%= @likes %>
+              </span>
+            </div>
           </div>
-        </div>
-        <div data-controller="collect"
-              data-collect-id-value="<%= @note.id %>"
-              class="mx-3">
-          <a data-action="collect#addCollection">
-            <%= collection_icon(current_user, @note) %>
-          </a>
-        </div>
-        <div>
-          <button class="w-8 h-8 border border-gray-300 mr-8 rounded flex justify-center items-center"
-                  data-action="commentToggle#toggle">
-            <i class="fas fa-comment-dots text-sm text-gray-lightest_s bg-white"></i>
-          </button>
+          <div data-controller="collect"
+                data-collect-id-value="<%= @note.id %>"
+                class="mx-3">
+            <a data-action="collect#addCollection">
+              <%= collection_icon(current_user, @note) %>
+            </a>
+          </div>
+          <div>
+            <button class="w-8 h-8 border border-gray-300 mr-8 rounded flex justify-center items-center"
+                    data-action="commentToggle#toggle">
+              <i class="fas fa-comment-dots text-sm text-gray-lightest_s bg-white"></i>
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
   
-  <div data-commentToggle-target="display"
-          style="display: none;"
-          class="mx-4 my-2 border border-gray-300 rounded w-60 overflow-y-scroll relative z-10 bg-white">
-    <div id="comments" class="mt-2">
-      <%= render "comments", comments: @comments %>
-    </div>
-    <div>
-      <%= render "createComment", note: @note, comment: @comment %>
+  
+    <div data-commentToggle-target="display"
+            style="display: none;"
+            class="mx-4 my-2 border border-gray-300 rounded w-60 overflow-y-scroll relative z-10 bg-white">
+      <div id="comments" class="mt-2">
+        <%= render "comments", comments: @comments %>
+      </div>
+      <div>
+        <%= render "createComment", note: @note, comment: @comment %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -36,55 +36,60 @@
       </button>
   </div>
 </nav>
-<div class="relative">
-  <div class="absolute right-16 top-12 z-10">
-    <div class="flex items-center">
-      <div class="icon-btns">
-        <div data-controller="favorite"
-            data-favorite-id-value="<%= @note.id %>">
-          <a href="#"
-            id = "favorite_btn"
-            data-action="favorite#addFavorite"
-            data-id="<%= @note.id %>">
-            <%= favorite_icon(current_user, @note) %>
+
+<div class="flex"
+     data-controller="commentToggle">
+  <div class="relative w-screen">
+    <div id="editor" data-controller="autosave"
+                     data-action="keyup->autosave#updateValue"
+                     data-addTags-target="editor"
+                     data-addTags-id-value="<%= @note.id %>"
+                     data-autosave-id-value="<%= @note.id %>"
+                     data-content="<%= @note.content %>"
+                     class="w-full">
+    </div>
+    <div class="absolute right-0 top-12 z-10">
+      <div class="flex items-center">
+        <div class="icon-btns">
+          <div data-controller="favorite"
+              data-favorite-id-value="<%= @note.id %>">
+            <a href="#"
+              id = "favorite_btn"
+              data-action="favorite#addFavorite"
+              data-id="<%= @note.id %>">
+              <%= favorite_icon(current_user, @note) %>
+            </a>
+            <span data-favorite-target='counter' >
+              <%= @likes %>
+            </span>
+          </div>
+        </div>
+        <div data-controller="collect"
+              data-collect-id-value="<%= @note.id %>"
+              class="mx-3">
+          <a data-action="collect#addCollection">
+            <%= collection_icon(current_user, @note) %>
           </a>
-          <span data-favorite-target='counter' >
-            <%= @likes %>
-          </span>
+        </div>
+        <div>
+          <button class="w-8 h-8 border border-gray-300 mr-8 rounded flex justify-center items-center"
+                  data-action="commentToggle#toggle">
+            <i class="fas fa-comment-dots text-sm text-gray-lightest_s bg-white"></i>
+          </button>
         </div>
       </div>
-      <div data-controller="collect"
-           data-collect-id-value="<%= @note.id %>">
-        <a data-action="collect#addCollection">
-          <%= collection_icon(current_user, @note) %>
-        </a>
-      </div>
     </div>
   </div>
-</div>
-<div class="relative">
-  <div data-controller="commentToggle"
-                    class="flex absolute right-8 top-20 z-10">
-    <button class="w-8 h-8 border border-gray-300 mr-8 rounded flex justify-center items-center"
-            data-action="commentToggle#toggle">
-      <i class="fas fa-comment-dots text-sm text-gray-lightest_s"></i>
-    </button>
-    <div data-commentToggle-target="display"
+
+  
+  <div data-commentToggle-target="display"
           style="display: none;"
-          class="mr-4 mt-8 border border-gray-300 rounded w-60 overflow-y-scroll">
-      <div id="comments" class="mt-2">
-        <%= render "comments", comments: @comments %>
-      </div>
-      <div class="">
-        <%= render "createComment", note: @note, comment: @comment %>
-      </div>
+          class="mx-4 my-2 border border-gray-300 rounded w-60 overflow-y-scroll relative z-10 bg-white">
+    <div id="comments" class="mt-2">
+      <%= render "comments", comments: @comments %>
+    </div>
+    <div>
+      <%= render "createComment", note: @note, comment: @comment %>
     </div>
   </div>
 </div>
-<div id="editor" data-controller="autosave"
-                   data-action="keyup->autosave#updateValue"
-                   data-addTags-target="editor"
-                   data-addTags-id-value="<%= @note.id %>"
-                   data-autosave-id-value="<%= @note.id %>"
-                   data-content="<%= @note.content %>"></div>
-                   <%# keyup->addTags#findTags addTags %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -36,47 +36,43 @@
       </button>
   </div>
 </nav>
-
-
-        <div class="icon-btns">
-          <div data-controller="favorite"
-              data-favorite-id-value="<%= @note.id %>">
-            <a href="#"
-              id = "favorite_btn"
-              data-action="favorite#addFavorite"
-              data-id="<%= @note.id %>">
-              <%= favorite_icon(current_user, @note) %>
-            </a>
-            <span data-favorite-target='counter' >
-              <%= @likes %>
-            </span>
-          </div>
-          <div data-controller="collect"
-              data-collect-id-value="<%= @note.id %>">
-            <a data-action="collect#addCollection">
-              <%= collection_icon(current_user, @note) %>
-            </a>
-          </div>
-        </div>
-
+<div class="icon-btns">
+  <div data-controller="favorite"
+      data-favorite-id-value="<%= @note.id %>">
+    <a href="#"
+      id = "favorite_btn"
+      data-action="favorite#addFavorite"
+      data-id="<%= @note.id %>">
+      <%= favorite_icon(current_user, @note) %>
+    </a>
+    <span data-favorite-target='counter' >
+      <%= @likes %>
+    </span>
+  </div>
+  <div data-controller="collect"
+      data-collect-id-value="<%= @note.id %>">
+    <a data-action="collect#addCollection">
+      <%= collection_icon(current_user, @note) %>
+    </a>
+  </div>
+</div>
+<div data-controller="commentToggle"
+          class="flex">
+  <button class="w-8 h-8 border border-gray-300 mr-8 rounded mt-6 flex justify-center items-center"
+          data-action="commentToggle#toggle">
+    <i class="fas fa-comment-dots text-sm text-gray-lightest_s"></i>
+  </button>
+  <div data-commentToggle-target="display"
+        style="display: none;"
+        class="mr-4 my-6 border border-gray-300 rounded w-60 overflow-y-scroll">
+    <div id="comments" class="mt-2">
+      <%= render "comments", comments: @comments %>
     </div>
-    <div data-controller="commentToggle"
-              class="flex">
-      <button class="w-8 h-8 border border-gray-300 mr-8 rounded mt-6 flex justify-center items-center"
-              data-action="commentToggle#toggle">
-        <i class="fas fa-comment-dots text-sm text-gray-lightest_s"></i>
-      </button>
-      <div data-commentToggle-target="display"
-           style="display: none;"
-           class="mr-4 my-6 border border-gray-300 rounded w-60 overflow-y-scroll">
-        <div id="comments" class="mt-2">
-          <%= render "comments", comments: @comments %>
-        </div>
-        <div class="">
-          <%= render "createComment", note: @note, comment: @comment %>
-        </div>
-      </div>
+    <div class="">
+      <%= render "createComment", note: @note, comment: @comment %>
     </div>
+  </div>
+</div>
 <div id="editor" data-controller="autosave"
                  data-action="keyup->autosave#updateValue"
                  data-addTags-target="editor"

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -36,47 +36,55 @@
       </button>
   </div>
 </nav>
-<div class="icon-btns">
-  <div data-controller="favorite"
-      data-favorite-id-value="<%= @note.id %>">
-    <a href="#"
-      id = "favorite_btn"
-      data-action="favorite#addFavorite"
-      data-id="<%= @note.id %>">
-      <%= favorite_icon(current_user, @note) %>
-    </a>
-    <span data-favorite-target='counter' >
-      <%= @likes %>
-    </span>
-  </div>
-  <div data-controller="collect"
-      data-collect-id-value="<%= @note.id %>">
-    <a data-action="collect#addCollection">
-      <%= collection_icon(current_user, @note) %>
-    </a>
+<div class="relative">
+  <div class="absolute right-16 top-12 z-10">
+    <div class="flex items-center">
+      <div class="icon-btns">
+        <div data-controller="favorite"
+            data-favorite-id-value="<%= @note.id %>">
+          <a href="#"
+            id = "favorite_btn"
+            data-action="favorite#addFavorite"
+            data-id="<%= @note.id %>">
+            <%= favorite_icon(current_user, @note) %>
+          </a>
+          <span data-favorite-target='counter' >
+            <%= @likes %>
+          </span>
+        </div>
+      </div>
+      <div data-controller="collect"
+           data-collect-id-value="<%= @note.id %>">
+        <a data-action="collect#addCollection">
+          <%= collection_icon(current_user, @note) %>
+        </a>
+      </div>
+    </div>
   </div>
 </div>
-<div data-controller="commentToggle"
-          class="flex">
-  <button class="w-8 h-8 border border-gray-300 mr-8 rounded mt-6 flex justify-center items-center"
-          data-action="commentToggle#toggle">
-    <i class="fas fa-comment-dots text-sm text-gray-lightest_s"></i>
-  </button>
-  <div data-commentToggle-target="display"
-        style="display: none;"
-        class="mr-4 my-6 border border-gray-300 rounded w-60 overflow-y-scroll">
-    <div id="comments" class="mt-2">
-      <%= render "comments", comments: @comments %>
-    </div>
-    <div class="">
-      <%= render "createComment", note: @note, comment: @comment %>
+<div class="relative">
+  <div data-controller="commentToggle"
+                    class="flex absolute right-8 top-20 z-10">
+    <button class="w-8 h-8 border border-gray-300 mr-8 rounded flex justify-center items-center"
+            data-action="commentToggle#toggle">
+      <i class="fas fa-comment-dots text-sm text-gray-lightest_s"></i>
+    </button>
+    <div data-commentToggle-target="display"
+          style="display: none;"
+          class="mr-4 mt-8 border border-gray-300 rounded w-60 overflow-y-scroll">
+      <div id="comments" class="mt-2">
+        <%= render "comments", comments: @comments %>
+      </div>
+      <div class="">
+        <%= render "createComment", note: @note, comment: @comment %>
+      </div>
     </div>
   </div>
 </div>
 <div id="editor" data-controller="autosave"
-                 data-action="keyup->autosave#updateValue"
-                 data-addTags-target="editor"
-                 data-addTags-id-value="<%= @note.id %>"
-                 data-autosave-id-value="<%= @note.id %>"
-                 data-content="<%= @note.content %>"></div>
-                 <%# keyup->addTags#findTags addTags %>
+                   data-action="keyup->autosave#updateValue"
+                   data-addTags-target="editor"
+                   data-addTags-id-value="<%= @note.id %>"
+                   data-autosave-id-value="<%= @note.id %>"
+                   data-content="<%= @note.content %>"></div>
+                   <%# keyup->addTags#findTags addTags %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -19,7 +19,7 @@
       </i>
       <div data-commentToggle-target="display"
             style="display: none;"
-            class="bg-white w-56 p-4 shadow absolute top-full right-20 z-10">
+            class="bg-white w-56 p-4 shadow absolute top-full right-20 z-20">
         <div class="text-xs text-gray-light">
           公開發表
         </div>


### PR DESCRIPTION
已完成：
1. 調整按讚、收藏、留言位置至editor內
2. 留言縮放可顯示在editor外

已修正：
1. React Markdown 造成的 console 內錯誤
2. 讓 editor 能夠正常換行
3. 取消 editor 空白行的紅點
<img width="1440" alt="截圖 2021-09-29 下午11 24 33" src="https://user-images.githubusercontent.com/31040771/135301249-2871b69b-da15-4fb5-9540-8dcc20093cb9.png">
<img width="1440" alt="截圖 2021-09-29 下午11 34 21" src="https://user-images.githubusercontent.com/31040771/135301472-89ed5bf6-8dc3-45c9-9fc1-1ac3a3f17c14.png">


