### PR TITLE
修正個人公開頁顯示的內文

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,7 +2,7 @@ class NotesController < ApplicationController
   before_action :authenticate_user!
   before_action :find_user_note, only: [:edit, :update, :destroy]
   def index
-    @notes = current_user.notes.order(updated_at: :desc).search(params[:search]).page(params[:page])
+    @notes = current_user.notes.order(updated_at: params[:desc] || :desc).search(params[:search]).page(params[:page])
     @tags = Tag.all
   end
 

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -11,7 +11,6 @@ class Users::ProfilesController < ApplicationController
 
   def private_note
     @notes = @user.notes.order(updated_at: params[:desc] || :desc)
-                        .where(user_id: params[:id])
                         .search(params[:search])
                         .page(params[:page])  
   end

--- a/app/views/notes/_side_bar.html.erb
+++ b/app/views/notes/_side_bar.html.erb
@@ -9,8 +9,7 @@
       <% end %>
     </li>
     <li>
-      <%# <div class="input-bar"> %>
-        <div class="flex items-center">
+      <div class="flex items-center">
         <i class="fas fa-search"></i>
         <div>
           <%= form_tag(notes_path, :method => "get") do %>
@@ -33,12 +32,6 @@
         <span class="links_name">我的筆記</span>
       <% end %>
     </li>
-    <li>
-      <%= link_to notes_path do %>
-        <i class="fas fa-users"></i>
-        <span class="links_name">協作筆記</span>
-      <% end %>
-    </li>
   </ul>
   <ul class="nave-list list2 w-full">
     <li>
@@ -46,12 +39,6 @@
         <i class="fas fa-bookmark"></i>
         <span class="links_name">收藏</span>
       <% end %>
-    </li>
-    <li>
-      <a>
-        <i class="far fa-clock"></i>
-        <span class="links_name">最近瀏覽</span>
-      </a>
     </li>
     <li class="user_info px-4">
       <div class="flex">

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -30,7 +30,31 @@
           <% end %>
         </ul>
       </div>
-      <span href="#" class="note-index-btn px-3 cursor-pointer">顯示方式</span>
+      <button class="w-32 px-2 border border-gray-200 bg-gray-rackmd text-white relative hover:bg-gray-200 hover:text-gray-700"
+              data-controller="commentToggle" 
+              data-action="commentToggle#toggle">
+        <div class="flex justify-between items-center">
+          <div class="">顯示方式</div>
+          <div>
+            <i class="fas fa-chevron-down w-full h-5 flex items-center justify-center"></i>
+          </div>
+        </div>
+        <div class="absolute top-full right-0 mt-0.5 py-2 w-40 bg-gray-light rounded"
+              style="display: none;"
+              data-commentToggle-target="display">
+          <div class="text-gray-300 text-base text-left px-4">
+            筆記排序
+          </div>
+          <div class="text-sm">
+            <%= link_to "新到舊",
+                        notes_path(desc: 'desc'),
+                        class:"block text-left py-0.5 px-4 text-gray-200 hover:bg-gray-400" %>
+            <%= link_to "舊到新", 
+                        notes_path(desc: 'asc'),
+                        class:"block text-left py-0.5 px-4 text-gray-200 hover:bg-gray-400" %>
+          </div>
+        </div>
+      </button>
     </div>
     <div>
       <hr class="mb-10">

--- a/app/views/users/collections/index.html.erb
+++ b/app/views/users/collections/index.html.erb
@@ -37,7 +37,7 @@
             <%= link_to note.title, note_path(note) %>
           </h2>
           <p class= "text-gray-400 text-base">
-            <%= truncate note.content.remove(note.title,",","•"), length: 50 %>
+            <%= truncate note.content.remove(note.title,",","•","#"), length: 50 %>
           </p>
           <div class="flex text-gray-400 text-sm">
             <div>

--- a/app/views/users/collections/index.html.erb
+++ b/app/views/users/collections/index.html.erb
@@ -37,7 +37,7 @@
             <%= link_to note.title, note_path(note) %>
           </h2>
           <p class= "text-gray-400 text-base">
-            <%= note.content %>
+            <%= truncate note.content.remove(note.title,",","•"), length: 50 %>
           </p>
           <div class="flex text-gray-400 text-sm">
             <div>

--- a/app/views/users/profiles/like_note.html.erb
+++ b/app/views/users/profiles/like_note.html.erb
@@ -61,7 +61,7 @@
           <%= link_to note.title, note_path(note) %>
         </h2>
         <p class= "text-gray-400 text-base">
-          <%= note.content %>
+          <%= truncate note.content.remove(note.title,",","•","#"), length: 50 %>
         </p>
         <div class="flex text-gray-400 text-sm">
           <div>

--- a/app/views/users/profiles/private_note.html.erb
+++ b/app/views/users/profiles/private_note.html.erb
@@ -62,8 +62,6 @@
         </h2>
         <p class= "text-gray-400 text-base">
           <%= truncate note.content.remove(note.title,",","•","#"), length: 50 %>
-          <%# truncate note.content, length: 50 %>
-          <%# note.content %>
         </p>
         <div class="flex text-gray-400 text-sm">
           <div>

--- a/app/views/users/profiles/private_note.html.erb
+++ b/app/views/users/profiles/private_note.html.erb
@@ -61,7 +61,9 @@
           <%= link_to note.title, note_path(note) %>
         </h2>
         <p class= "text-gray-400 text-base">
-          <%= note.content %>
+          <%= truncate note.content.remove(note.title,",","•","#"), length: 50 %>
+          <%# truncate note.content, length: 50 %>
+          <%# note.content %>
         </p>
         <div class="flex text-gray-400 text-sm">
           <div>

--- a/app/views/users/profiles/public_note.html.erb
+++ b/app/views/users/profiles/public_note.html.erb
@@ -61,7 +61,7 @@
           <%= link_to note.title, note_path(note) %>
         </h2>
         <p class= "text-gray-400 text-base">
-          <%= note.content %>
+          <%= truncate note.content.remove(note.title,",","•","#"), length: 50 %>
         </p>
         <div class="flex text-gray-400 text-sm">
           <div>


### PR DESCRIPTION
已修改：
1. 個人公開頁跟收藏的內文可以正常顯示，不會有奇怪的符號，且限制顯示字數為50字
2. 刪除協作筆記、最近瀏覽按鈕

新增：
1. index 頁面筆記排序按鈕
![截圖 2021-09-30 下午6 48 31](https://user-images.githubusercontent.com/31040771/135442311-2201f986-2633-4583-9595-43867fb5a34d.png)

![截圖 2021-09-30 下午6 49 16](https://user-images.githubusercontent.com/31040771/135442314-7c02d47d-cb63-428b-b653-f9eb2439c31b.png)
![截圖 2021-09-30 下午6 49 38](https://user-images.githubusercontent.com/31040771/135442324-a76daf01-423c-49a1-81df-735fba6bd1a2.png)


